### PR TITLE
feat : добавлены флаги для запуска server и agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -12,17 +12,19 @@ import (
 func main() {
 
 	serverAddr := flag.String("a", "localhost:8080", "Server address host:port, default: localhost:8080")
-	pollInterval := flag.Duration("p", 2, "Poll interval, default: 2s")
-	reportInterval := flag.Duration("r", 10, "Report interval, default: 10s")
+	pollIntervalSec := flag.Int("p", 2, "Poll interval, default: 2s")
+	reportIntervalSec := flag.Int("r", 10, "Report interval, default: 10s")
 
 	flag.Parse()
 
 	serverURL := "http://" + *serverAddr
+	pollInterval := time.Duration(*pollIntervalSec) * time.Second
+	reportInterval := time.Duration(*reportIntervalSec) * time.Second
 
-	pollsPerReport := int(*reportInterval / *pollInterval)
+	pollsPerReport := *pollIntervalSec / *reportIntervalSec
 
 	fmt.Printf("Starting agent: server=%s, poll=%v, report=%v",
-		serverURL, *pollInterval, *reportInterval)
+		serverURL, pollInterval, reportInterval)
 
 	for {
 		var metrics []models.Metrics
@@ -31,12 +33,12 @@ func main() {
 			metrics = agent.Collect()
 
 			if i < pollsPerReport-1 {
-				time.Sleep(*pollInterval)
+				time.Sleep(pollInterval)
 			}
 		}
 		agent.Send(metrics, serverURL)
 
-		time.Sleep(*pollInterval)
+		time.Sleep(pollInterval)
 
 	}
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"time"
 
 	"github.com/as-tanais/observy/internal/agent"
@@ -8,10 +10,19 @@ import (
 )
 
 func main() {
-	pollInterval := 2 * time.Second
-	reportInterval := 10 * time.Second
 
-	pollsPerReport := int(reportInterval / pollInterval)
+	serverAddr := flag.String("a", "localhost:8080", "Server address host:port, default: localhost:8080")
+	pollInterval := flag.Duration("p", 2*time.Second, "Poll interval, default: 2s")
+	reportInterval := flag.Duration("r", 10*time.Second, "Report interval, default: 10s")
+
+	flag.Parse()
+
+	serverURL := "http://" + *serverAddr
+
+	pollsPerReport := int(*reportInterval / *pollInterval)
+
+	fmt.Printf("Starting agent: server=%s, poll=%v, report=%v",
+		serverURL, *pollInterval, *reportInterval)
 
 	for {
 		var metrics []models.Metrics
@@ -20,12 +31,12 @@ func main() {
 			metrics = agent.Collect()
 
 			if i < pollsPerReport-1 {
-				time.Sleep(pollInterval)
+				time.Sleep(*pollInterval)
 			}
 		}
-		agent.Send(metrics)
+		agent.Send(metrics, serverURL)
 
-		time.Sleep(pollInterval)
+		time.Sleep(*pollInterval)
 
 	}
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -21,7 +21,7 @@ func main() {
 	pollInterval := time.Duration(*pollIntervalSec) * time.Second
 	reportInterval := time.Duration(*reportIntervalSec) * time.Second
 
-	pollsPerReport := *pollIntervalSec / *reportIntervalSec
+	pollsPerReport := *reportIntervalSec / *pollIntervalSec
 
 	fmt.Printf("Starting agent: server=%s, poll=%v, report=%v",
 		serverURL, pollInterval, reportInterval)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -12,8 +12,8 @@ import (
 func main() {
 
 	serverAddr := flag.String("a", "localhost:8080", "Server address host:port, default: localhost:8080")
-	pollInterval := flag.Duration("p", 2*time.Second, "Poll interval, default: 2s")
-	reportInterval := flag.Duration("r", 10*time.Second, "Report interval, default: 10s")
+	pollInterval := flag.Duration("p", 2, "Poll interval, default: 2s")
+	reportInterval := flag.Duration("r", 10, "Report interval, default: 10s")
 
 	flag.Parse()
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/http"
 
@@ -18,6 +19,9 @@ func main() {
 
 func run() error {
 
+	serverAddr := flag.String("a", "localhost:8080", "Server address (host:port)")
+	flag.Parse()
+
 	storage := repository.NewMemStorage()
 	service := service.NewMetricsService(storage)
 	metricshandler := handler.NewMetricsHandler(service)
@@ -28,7 +32,7 @@ func run() error {
 	router.Get("/value/{type}/{name}", metricshandler.GetMetricHandler)
 	router.Get("/", metricshandler.ListMetricsHandler)
 
-	fmt.Println("Starting server on :8080")
+	fmt.Printf("Starting server on %s", *serverAddr)
 
-	return http.ListenAndServe(`:8080`, router)
+	return http.ListenAndServe(*serverAddr, router)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -59,16 +59,12 @@ func TestSend_URLFormat(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalAddress := serverAddress
-	serverAddress = server.URL
-	defer func() { serverAddress = originalAddress }()
-
 	value := 123.45
 	testMetrics := []models.Metrics{
 		{ID: "TestGauge", MType: models.Gauge, Value: &value},
 	}
 
-	Send(testMetrics)
+	Send(testMetrics, server.URL)
 
 	expectedPath := "/update/gauge/TestGauge/123.450000"
 	assert.Equal(t, expectedPath, capturedPath, "URL должен соответствовать формату /update/{type}/{name}/{value}")
@@ -87,16 +83,12 @@ func TestSend_CounterMetric(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalAddress := serverAddress
-	serverAddress = server.URL
-	defer func() { serverAddress = originalAddress }()
-
 	delta := int64(42)
 	testMetrics := []models.Metrics{
 		{ID: "PollCount", MType: models.Counter, Delta: &delta},
 	}
 
-	Send(testMetrics)
+	Send(testMetrics, server.URL)
 
 	expectedPath := "/update/counter/PollCount/42"
 	assert.Equal(t, expectedPath, capturedPath, "Путь должен содержать counter тип и целое значение")
@@ -117,10 +109,6 @@ func TestSend_MultipleMetrics(t *testing.T) {
 	}))
 	defer server.Close()
 
-	originalAddress := serverAddress
-	serverAddress = server.URL
-	defer func() { serverAddress = originalAddress }()
-
 	gaugeValue := 100.5
 	counterDelta := int64(5)
 
@@ -130,7 +118,7 @@ func TestSend_MultipleMetrics(t *testing.T) {
 		{ID: "Sys", MType: models.Gauge, Value: &gaugeValue},
 	}
 
-	Send(testMetrics)
+	Send(testMetrics, server.URL)
 
 	assert.Equal(t, 3, requestCount, "Должно быть отправлено 3 запроса")
 

--- a/internal/agent/sender.go
+++ b/internal/agent/sender.go
@@ -8,9 +8,7 @@ import (
 	models "github.com/as-tanais/observy/internal/model"
 )
 
-var serverAddress = "http://localhost:8080"
-
-func Send(metrics []models.Metrics) {
+func Send(metrics []models.Metrics, serverAddress string) {
 	client := &http.Client{}
 
 	for _, metric := range metrics {

--- a/internal/agent/sender.go
+++ b/internal/agent/sender.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	models "github.com/as-tanais/observy/internal/model"
 )
 
+var httpClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
 func Send(metrics []models.Metrics, serverAddress string) {
-	client := &http.Client{}
 
 	for _, metric := range metrics {
 		var value string
@@ -20,18 +24,18 @@ func Send(metrics []models.Metrics, serverAddress string) {
 			if metric.Value != nil {
 				value = fmt.Sprintf("%f", *metric.Value)
 			} else {
-				log.Printf("Пропущена gauge метрика %s: значение nil", metric.ID)
+				log.Printf("Пропущена gauge метрика %s: значение nil\n", metric.ID)
 				continue
 			}
 		case models.Counter:
 			if metric.Delta != nil {
 				value = fmt.Sprintf("%d", *metric.Delta)
 			} else {
-				log.Printf("Пропущена counter метрика %s: значение nil", metric.ID)
+				log.Printf("Пропущена counter метрика %s: значение nil\n", metric.ID)
 				continue
 			}
 		default:
-			log.Printf("Неизвестный тип метрики: %s", metric.MType)
+			log.Printf("Неизвестный тип метрики: %s\n", metric.MType)
 			continue
 		}
 
@@ -41,7 +45,7 @@ func Send(metrics []models.Metrics, serverAddress string) {
 		// Создаём запрос
 		req, err := http.NewRequest(http.MethodPost, url, nil)
 		if err != nil {
-			log.Printf("Ошибка создания запроса для %s: %v", metric.ID, err)
+			log.Printf("Ошибка создания запроса для %s: %v\n", metric.ID, err)
 			continue
 		}
 
@@ -49,9 +53,9 @@ func Send(metrics []models.Metrics, serverAddress string) {
 		req.Header.Set("Content-Type", "text/plain")
 
 		// Отправляем запрос
-		resp, err := client.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
-			log.Printf("Ошибка отправки метрики %s: %v", metric.ID, err)
+			log.Printf("Ошибка отправки метрики %s: %v\n", metric.ID, err)
 			continue
 		}
 
@@ -60,7 +64,7 @@ func Send(metrics []models.Metrics, serverAddress string) {
 
 		// Проверяем статус ответа
 		if resp.StatusCode != http.StatusOK {
-			log.Printf("Метрика %s: неожиданный статус %d", metric.ID, resp.StatusCode)
+			log.Printf("Метрика %s: неожиданный статус %d\ns", metric.ID, resp.StatusCode)
 		}
 	}
 }


### PR DESCRIPTION
Добавлены аргументы командной строки для запуска сервера и агента.

Аргументы сервера:
Флаг -a=<ЗНАЧЕНИЕ> отвечает за адрес эндпоинта HTTP-сервера (по умолчанию localhost:8080).
Аргументы агента:
Флаг -a=<ЗНАЧЕНИЕ> отвечает за адрес эндпоинта HTTP-сервера (по умолчанию localhost:8080).
Флаг -r=<ЗНАЧЕНИЕ> позволяет переопределять reportInterval — частоту отправки метрик на сервер (по умолчанию 10 секунд).
Флаг -p=<ЗНАЧЕНИЕ> позволяет переопределять pollInterval — частоту опроса метрик из пакета runtime (по умолчанию 2 секунды).